### PR TITLE
Simplification de lien

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -123,7 +123,7 @@
 
         <h2>Podium</h2>
         La <span style="font-size: 20px;"><b>France</b></span> est acuellement classée <b>#<span id="classement-france" style="font-size: 20px;"></span></b> sur 27 en couverture vaccinale partielle. Vous pouvez supporter ce pays en publiant un
-        <a id="tweet" class="twitter-share-button" href="" data-size="large"><button class="btn btn-primary btn-sm">Tweet</button></a> !
+        <a id="tweet" class="twitter-share-button btn btn-primary btn-sm" href="" data-size="large">Tweet</a> !
         <br>Podium actuel des trois pays européens qui ont vacciné la plus grande proportion de la population (avec au moins une dose).
 
         <div class="bodypodium">
@@ -143,7 +143,7 @@
         <iframe src="https://ourworldindata.org/explorers/coronavirus-data-explorer?zoomToSelection=true&pickerSort=desc&pickerMetric=total_vaccinations&Metric=People+vaccinated&Interval=Cumulative&Relative+to+Population=true&Align+outbreaks=false&country=AUT~BEL~BGR~HRV~CYP~CZE~DNK~EST~FIN~FRA~DEU~HUN~GRC~IRL~ITA~LVA~LTU~LUX~MLT~NLD~POL~PRT~ROU~SVK~SVN~ESP~SWE&hideControls=true" loading="lazy" style="width: 100%; height: 600px; max-width: 900px; border: 0px none;"></iframe>
 
         <h2 id="reserver" style="margin-top: 100px;">Réserver un créneau de vaccination</h2>
-        Vous pouvez réserver un créneau de vaccination covid facilement et rapidement sur <a href="https://vitemadose.covidtracker.fr"><button class="btn btn-primary">Vite Ma Dose</button></a>
+        Vous pouvez réserver un créneau de vaccination covid facilement et rapidement sur <a href="https://vitemadose.covidtracker.fr" class="btn btn-primary">Vite Ma Dose</a>
 
         <h2 id="about" style="margin-top: 100px;">À propos</h2>
         <p>EuroVaccination est une plateforme de CovidTracker permettant de suivre l'évolution de la campagne de vaccination dans les différents pays européens. Données : Our World In Data.</p>


### PR DESCRIPTION
Il vaut mieux éviter de placer un bouton (élément interactif) dans un lien (autre élément interactif) en HTML.